### PR TITLE
Fixing bug with improperly printed emoji

### DIFF
--- a/src/modules/CurrencyModule.cpp
+++ b/src/modules/CurrencyModule.cpp
@@ -873,7 +873,7 @@ CurrencyModule::CurrencyModule(UmikoBot* client) : Module("currency", true), m_c
 			}
 			if (user.bot())
 			{
-				client.createMessage(message.channelId(), "Just _who_ do you think supplies your money here? Donate it to someone else! :angryping:");
+				client.createMessage(message.channelId(), QString("**Just _who_ do you think supplies your money here? Donate it to someone else!** <:") + utility::consts::emojis::reacts::ANGRY_PING + QString(">"));
 				return;
 			}
 		}


### PR DESCRIPTION
The angry ping emoji didn't print correctly because it references an incorrect ID. This fixes that.